### PR TITLE
Adding hashes for updated shaders in DMM version from 6/10/2020

### DIFF
--- a/DOAX-VenusVacation/d3dx.ini
+++ b/DOAX-VenusVacation/d3dx.ini
@@ -1699,6 +1699,19 @@ run = CommandListFingernailsEyes
 hash = 3c779f31af0270f4
 run = CommandListFingernailsEyes
 
+[ShaderOverrideFindernailsPS2-Old]
+; Honoka Nails with Orange R Suit
+; Bytecode hash: 2497d817
+hash = 328e3db9bc84d1fd
+run = CommandListFingernailsEyes
+[ShaderOverrideFingernailsPS2-20190425]
+; Bytecode hash: ?
+hash = 61890a62ecccb6ff
+run = CommandListFingernailsEyes
+[ShaderOverrideFingernailsPS2-20200614]
+; Bytecode hash: 0ad5118e
+hash = 74f3dfe5ffc64d2f
+run = CommandListFingernailsEyes
 
 [ShaderOverrideEyesPS-Old]
 ; Bytecode hash: fea73a0d

--- a/DOAX-VenusVacation/d3dx.ini
+++ b/DOAX-VenusVacation/d3dx.ini
@@ -1782,7 +1782,7 @@ if $dump_hair_fingernails
 	dump = deferred_ctx_accurate share_dupes ps-t3 mono dds
 endif
 ; If you aren't using hair mods, it may be worth commenting out the section below
-if $costume_mods
+if $costume_mods && (!frame_analysis || $dump_modded_meshes)
 	checktextureoverride = ps-t0
 	checktextureoverride = ps-t1
 	checktextureoverride = ps-t2

--- a/DOAX-VenusVacation/d3dx.ini
+++ b/DOAX-VenusVacation/d3dx.ini
@@ -1787,6 +1787,12 @@ if $costume_mods
 	checktextureoverride = ps-t1
 	checktextureoverride = ps-t2
 	checktextureoverride = ps-t3
+	ResourceBakVB = ref vb0
+	ResourceBakIB = ref ib
+	checktextureoverride = vb0
+	checktextureoverride = ib
+	vb0 = ref ResourceBakVB
+	ib = ref ResourceBakIB
 endif
 
 [ResourceBakVB]

--- a/DOAX-VenusVacation/d3dx.ini
+++ b/DOAX-VenusVacation/d3dx.ini
@@ -12,6 +12,7 @@
 ; ShaderRegex to keep them standalone).
 include_recursive = Mods
 exclude_recursive = DISABLED*
+exclude_recursive = desktop.ini
 
 ; This custom shader will automatically adjust the convergence to try to keep
 ; the game comfortable to look at no matter how the camera changes. Check the
@@ -935,6 +936,7 @@ fix_sv_position=0
 [ShaderOverrideBurstHUD]
 ; Bytecode hash: bac3ec63
 hash = 5050ec8dea4505b4
+$shader_type = 9
 ;pre dump = deferred_ctx_accurate o0
 ;post dump = deferred_ctx_accurate o0 jps_dds desc
 ;dump = deferred_ctx_accurate mono ps-t0
@@ -1307,9 +1309,13 @@ run = CommandListClothes
 ; Bytecode hash: b624d0cb
 hash = cd1af5c00ed7af8f
 run = CommandListClothes
+[ShaderOverrideClothesPS1-20200610]
+; Bytecode hash: c0085d08
+hash = f016b56d30ba5603
+run = CommandListClothes
 
 [ShaderOverrideClothesPS2-Old]
-; e.g. Marie Rose Butterfly
+; e.g. Marie Rose Butterfly, Takao Bikini
 ; Bytecode hash: 64739f23
 hash = 0f90e32cbda59134
 run = CommandListClothes
@@ -1317,8 +1323,13 @@ run = CommandListClothes
 ; Bytecode hash: d9dbb2d1
 hash = 4826b20c3accdf18
 run = CommandListClothes
+[ShaderOverrideClothesPS2-20200610]
+; Bytecode hash: 
+hash = 37d3e66b5d8a0361 
+run = CommandListClothes
 
 [ShaderOverrideClothesPS3-Old]
+; Marie Punk SR Shirts, Momiji Venus SSR Bikini
 ; Bytecode hash: 1939dcaf
 hash = a9646b83de59c964
 run = CommandListClothes
@@ -1326,24 +1337,37 @@ run = CommandListClothes
 ; Bytecode hash: a7f17c47
 hash = 20763c3bb0d90b5b
 run = CommandListClothes
+[ShaderOverrideClothesPS3-20200610]
+; Bytecode hash: 9e7d8967
+hash = 493f9498fa161f40
+run = CommandListClothes
 
-[ShaderOverrideClothesPS4]
-; Halloween bikini frills
+[ShaderOverrideClothesPS4-Old]
+; Halloween bikini frills, Takao Skirt
 ; Bytecode hash: 93b7f8cf - not found in 2018-12-06 update
 ; Bytecode hash: 3de8b0dc - Added gMaterialParam2 check
 ;hash = 2e475e8cc581dcba
 hash = 8ab8b0dcca924945
 run = CommandListClothes
-[ShaderOverrideClothesPS5]
+[ShaderOverrideClothesPS4-20200610]
+; Bytecode hash: 20955db8
+hash = 5ed99f004bf2fa7b
+run = CommandListClothes
+
+[ShaderOverrideClothesPS5-Old]
 ; Blue skirt transparent
 ; Bytecode hash: bdee738d - not found in 2018-12-06 update
 ; Bytecode hash: be9c4d42 - Added gMaterialParam2 check
 ;hash = b0d4617a6eb20697
 hash = ce2c2dbb7e0d7707
 run = CommandListClothes
+[ShaderOverrideClothesPS5-20200610]
+; Bytecode hash: 5a325488
+hash = 00643e627b04288f
+run = CommandListClothes
 
 [ShaderOverrideClothesPS6-Old]
-; e.g. Chinese dress panties
+; e.g. Chinese dress panties, volleyball
 ; Bytecode hash: c4c26ea9
 hash = 223a728e5c6bdce4
 run = CommandListClothes
@@ -1351,13 +1375,21 @@ run = CommandListClothes
 ; Bytecode hash: 19dd7e25
 hash = e01e4957d41c54d5
 run = CommandListClothes
+[ShaderOverrideClothesPS6-20200610]
+; Bytecode hash: e726ce9c
+hash = 31a53dca07ae4242
+run = CommandListClothes
 
-[ShaderOverrideClothesPS7]
+[ShaderOverrideClothesPS7-Old]
 ; Luna / Momiji Venus SSR Feathers
 ; Bytecode hash: 1c46f4c5 - not found in 2018-12-06 update
 ; Bytecode hash: 892131c3 - Added gMaterialParam2 check
 ;hash = ea81a1c90df9a8e6
 hash = 16f9684d723c8243
+run = CommandListClothes
+[ShaderOverrideClothesPS7-20200610]
+; Bytecode hash: 9585abb5
+hash = a0f5bfe5195c4502
 run = CommandListClothes
 
 [ShaderOverrideClothesPS8-Old]
@@ -1369,25 +1401,43 @@ run = CommandListClothes
 ; Bytecode hash: 8479a35b
 hash = 5af6c9fd4d23c6e0
 run = CommandListClothes
+[ShaderOverrideClothesPS8-20200610]
+; Bytecode hash: 7a8213e2
+hash = dd9678efa5efd982
+run = CommandListClothes
 
-[ShaderOverrideClothesPS9]
-; Cherry Blossoms Heart
+[ShaderOverrideClothesPS9-Old]
+; Cherry Blossoms Heart, Kasumi Martini Gemstone, Martini SR Hardware
 ; Bytecode hash: b0adc5a2
 hash = e6a0802f6b5a0285
 run = CommandListClothes
-[ShaderOverrideClothesPS10]
-; Common Mermaid | Martini SR SSR
+[ShaderOverrideClothesPS9-20200610]
+; Bytecode hash: 72899d57
+hash = 52c5ae3cdc7810ca
+run = CommandListClothes
+
+[ShaderOverrideClothesPS10-Old]
+; Common Mermaid | Martini SR SSR | Reindeer Bell
 ; Bytecode hash: 75e3e462
 hash = 7633276941ec4f7a
 run = CommandListClothes
-[ShaderOverrideClothesPS11]
+[ShaderOverrideClothesPS10-20200610]
+; Bytecode hash: 3ea17e58
+hash = c46741f26dabb5fd
+run = CommandListClothes
+
+[ShaderOverrideClothesPS11-Old]
 ; Transparent white cloth on black bikini
 ; Bytecode hash: c42e8e56
 hash = 746c0cfeba78dbd9
 run = CommandListClothes
+[ShaderOverrideClothesPS11-20200610]
+; Bytecode hash: f6c01e51
+hash = 1a57b0790b876d57
+run = CommandListClothes
 
 [ShaderOverrideClothesPS12-Old]
-; Destiny Child bikini text (?)
+; Destiny Child bikini text, Dusk Set Frills
 ; Bytecode hash: ab5e9fae
 hash = 088290cf9c3bf97e
 run = CommandListClothes
@@ -1395,11 +1445,90 @@ run = CommandListClothes
 ; Bytecode hash: 21cf1e72
 hash = 334a305914e33465
 run = CommandListClothes
+[ShaderOverrideClothesPS12-20200610]
+; Bytecode hash: df34aecb
+hash = 5c4ca403dd607603
+run = CommandListClothes
 
-[ShaderOverrideClothesPS13]
-; Hitomi Jeans SR
+[ShaderOverrideClothesPS13-Old]
+; Hitomi Jeans SR (top of jeans)
 ; Bytecode hash: 1ead111f
 hash = 074cff4a129d961c
+run = CommandListClothes
+[ShaderOverrideClothesPS13-20200610]
+; Bytecode hash: f92db6e8
+hash = 635329c855070942
+run = CommandListClothes
+
+[ShaderOverrideAccessoryLensePS-Old]
+; Glasses and Demist
+; Bytecodde hash: 3da2a1ac
+hash = 1e372bfddbafcfc9
+run = CommandListClothes
+allow_duplicate_hash=overrule
+[ShaderOverrideAccessoryLensePS-20200610]
+; Bytecode hash: 403a7529
+hash = 90413848ce1de931
+run = CommandListClothes
+allow_duplicate_hash=overrule
+
+[ShaderOverrideAccessoryLense2PS-Old]
+; R Glasses Accessory
+; Bytecode hash: b774b3fe
+hash = 729498951d2a50ab
+run = CommandListClothes
+[ShaderOverrideAccessoryLense2PS-20200610]
+; Bytecode hash: f05852d1
+hash = 0b9aa4f6b6e36b57
+run = CommandListClothes
+
+[ShaderOverrideAccessoryOpaquePS-Old]
+; Bytecode hash: bbfc187c
+hash = a670c2d1ee16a5fc
+run = CommandListClothes
+[ShaderOverrideAccessoryOpaquePS-20190425]
+; Bytecode hash: ?
+hash = d19d68505c1c8c72
+run = CommandListClothes
+[ShaderOverrideAccessoryOpaquePS-20200610]
+; Bytecode hash: 0930de3c
+hash = 1fadbf4b504896c5
+run = CommandListClothes
+
+[ShaderOverrideClothesFur-Old]
+; Bytecode hash: ?
+hash = 01f66fd20f225798
+run = CommandListClothes
+[ShaderOverrideClothesFur-20200610]
+; Bytecode hash: dd83e19f
+hash = 8523156c83176528
+run = CommandListClothes
+
+[ShaderOverrideClothesFoam-Old]
+hash = 9dc65b3b28b6f02d
+run = CommandListClothes
+[ShaderOverrideClothesFoam-20200610]
+; Bytecode hash: e9276891
+hash = 532bf5f5b6377205
+run = CommandListClothes
+
+[ShaderOverrideClothesFoamOutline-Old]
+; Bytecode hash: ?
+hash = f235ea841e8674d8
+run = CommandListClothes
+[ShaderOverrideClothesFoamOutline-20200610]
+; Bytecode hash: a783739d
+hash = 1455a221f955fa05
+run = CommandListClothes
+
+[ShaderOverrideClothesAnimation-Old]
+; Luna/Honoka Space suit w/ Animated Heart
+; Bytecode hash: 
+hash = c6e132593ad49c90
+run = CommandListClothes
+[ShaderOverrideClothesAnimation-20200610]
+; Bytecode hash: 1cc4e6cb
+hash = e75fdf498eeb3be0
 run = CommandListClothes
 
 
@@ -1409,30 +1538,49 @@ run = CommandListClothes
 ; resolve the problem, but at a slight performance cost), run frame analysis
 ; during burst, and look for the target TextureOverride being triggered from
 ; the ShaderRegex but no other section. It will be one of the last.
-[ShaderOverrideClothesPSBurst]
+[ShaderOverrideClothesPSBurst-Old]
+;common lemongrass bra neck ribbon, Takao
 ; Bytecode hash: a1b6318d - not found in 2018-12-06 update
 ; Bytecode hash: d86afb2b - Added gMaterialParam2 check
 ;hash = 238fedda1a50e7b7
 hash = 628e8dc5a3814884
 run = CommandListClothes
-[ShaderOverrideClothesPSBurst1]
+[ShaderOverrideClothesPSBurst-20200610]
+hash = 8bf9671dbd879cc6
+run = CommandListClothes
+
+[ShaderOverrideClothesPSBurst1-Old]
 ; Bytecode hash: b3e92812 - not found in 2018-12-06 update
 ; Bytecode hash: 33988ee4 - Added gMaterialParam2 check
 ;hash = 5054df7af9c9059e
 hash = c04de6e33cd91271
 run = CommandListClothes
-[ShaderOverrideClothesPSBurst2]
+[ShaderOverrideClothesPSBurst1-20200610]
+; Bytecode hash: ceb550b1
+hash = 2e7dea8ba1236554
+run = CommandListClothes
+
+[ShaderOverrideClothesPSBurst2-Old]
 ; Rare - used for the belt in one of the costumes
 ; Bytecode hash: 7f16544c - not found in 2018-12-06 update
 ; Bytecode hash: 9180c285 - Added gMaterialParam2 check
 ;hash = 3a01359f800c2f4c
 hash = 6101a5716d55a5a7
 run = CommandListClothes
-[ShaderOverrideClothesPSBurst3]
+[ShaderOverrideClothesPSBurst2-20200610]
+; Bytecode hash: e22e3493
+hash = 6a33c0fb1c16db9e
+run = CommandListClothes
+
+[ShaderOverrideClothesPSBurst3-Old]
 ; Bytecode hash: 48908c86 - not found in 2018-12-06 update
 ; Bytecode hash: 51deaa55 - Added gMaterialParam2 check
 ;hash = 5fd986755fa343bc
 hash = f3b49c6767bc8291
+run = CommandListClothes
+[ShaderOverrideClothesPSBurst3-20200610]
+; Bytecode hash: d3b599ca
+hash = 8936fc882dfd54d6
 run = CommandListClothes
 
 [ShaderOverrideClothesShadow]
@@ -1455,6 +1603,7 @@ if $dump_skin_clothes
 	analyse_options = deferred_ctx_accurate share_dupes dump_vb txt buf
 	; Dump skinning matrices:
 	dump = deferred_ctx_accurate vs-cb2 txt buf
+	dump = deferred_ctx_accurate ps-cb2 txt buf
 endif
 if $costume_mods && (!frame_analysis || $dump_modded_meshes)
 	; Enable costume texture replacement by texture hash:
@@ -1479,9 +1628,28 @@ run = CommandListSkin
 ; Bytecode hash: 682c84f5
 hash = 3d6c93879b0d5a0f
 run = CommandListSkin
-[ShaderOverrideSkinPSBurst]
+[ShaderOverrideSkinPS-20200610]
+; Bytecode hash: dcdc50c3
+hash = d4490acbf65bd5e3
+run = CommandListSkin
+
+[ShaderOverrideSkinMatsuge-Old]
+; Eyelashes
+; Bytecode hash: b6d5f1f4
+hash = 08178552fffb5040
+run = CommandListSkin
+[ShaderOverrideSkinMatsuge-20200610]
+; Bytecode hash: 00fa2225
+hash = f51ace621d700e10
+run = CommandListSkin
+
+[ShaderOverrideSkinPSBurst-Old]
 ; Bytecode hash: 2b712825
 hash = 01ea55a5f6611833
+run = CommandListSkin
+[ShaderOverrideSkinPSBurst-20200610]
+; Bytecode hash: c9b6b357
+hash = d51433e9122e0b53
 run = CommandListSkin
 
 [CommandListSkin]
@@ -1518,12 +1686,22 @@ run = CommandListShadowMap
 hash = 9fec56dfe369a768
 run = CommandListFingernailsEyes
 [ShaderOverrideFingernailsPS-20190425]
+; Bytecode hash: ?
 hash = 29c81a931743921b
 run = CommandListFingernailsEyes
+[ShaderOverrideFingernailsPS-20200610]
+; Bytecode hash: 6c4e0ccd
+hash = 3c779f31af0270f4
+run = CommandListFingernailsEyes
 
-[ShaderOverrideEyesPS]
+
+[ShaderOverrideEyesPS-Old]
 ; Bytecode hash: fea73a0d
 hash = 8f5e127ae4627ea7
+run = CommandListFingernailsEyes
+[ShaderOverrideEyesPS-20200610]
+; Bytecode hash: c4dfe078
+hash = deeb698c74ada082
 run = CommandListFingernailsEyes
 
 [CommandListFingernailsEyes]
@@ -1544,14 +1722,53 @@ if $costume_mods && (!frame_analysis || $dump_modded_meshes)
 	checktextureoverride = ib
 endif
 
-[ShaderOverrideHairPS1]
+[ShaderOverrideHairPS1-Old]
 ; Bytecode hash: 7f58ee80
 hash = 039e0fc28bd56fb1
 run = CommandListHair
-[ShaderOverrideHairPS2]
+[ShaderOverrideHairPS1-20200610]
+; Bytecode hash: 2a353ee8
+hash = c2701566e16d2708
+run = CommandListHair
+
+[ShaderOverrideHairPS2-Old]
 ; Bytecode hash: 2c7009d8
 hash = 2d6fa97beffe2f18
 run = CommandListHair
+[ShaderOverrideHairPS2-20200610]
+; Bytecode hash: 26ff680c
+hash = a07858cce6fb5e1e
+run = CommandListHair
+
+[ShaderOverrideHairPS3-Old]
+; Bytecode hash: 64b0715f
+hash = 503fb935ab855fb4
+run = CommandListHair
+[ShaderOverrideHairPS3-20200610]
+; Bytecode hash: 2c062602
+hash = 29a6bbe4fb3fb695
+run = CommandListHair
+
+[ShaderOverrideHairPS4-Old]
+; Marie Twintails
+; Bytecode hash: a0d2588a
+hash = 8cdfb147e69f571f
+run = CommandListHair
+[ShaderOverrideHairPS4-20200610]
+; Bytecode hash: d44e47e6
+hash = aee3e868603787ab
+run = CommandListHair
+
+[ShaderOverrideHairPS5-Old]
+; Momiji Hair
+; Bytecode hash: 93afcfd8
+hash = e700545df3484d4d
+run = CommandListHair
+[ShaderOverrideHairPS5-20200610]
+; Bytecode hash: 287b9c7c
+hash = 7624d48fb5ccb677
+run = CommandListHair
+
 [CommandListHair]
 $shader_type = 4
 if $dump_hair_fingernails
@@ -1564,19 +1781,20 @@ if $dump_hair_fingernails
 	dump = deferred_ctx_accurate share_dupes ps-t2 mono dds
 	dump = deferred_ctx_accurate share_dupes ps-t3 mono dds
 endif
-; Not enabling texture replacements of hair globally just yet since no one is
-; using them and there is a fair few of these each frame... enable these in a
-; mod's ini file if you want them
-;if $costume_mods
-;	checktextureoverride = ps-t0
-;	checktextureoverride = ps-t1
-;	checktextureoverride = ps-t2
-;	checktextureoverride = ps-t3
-;endif
+; If you aren't using hair mods, it may be worth commenting out the section below
+if $costume_mods
+	checktextureoverride = ps-t0
+	checktextureoverride = ps-t1
+	checktextureoverride = ps-t2
+	checktextureoverride = ps-t3
+endif
 
 [ResourceBakVB]
 [ResourceBakIB]
 [CommandListShadowMap]
+;analyse_options = deferred_ctx_accurate share_dupes dump_vb txt buf
+;dump = deferred_ctx_accurate vs-cb2 txt buf
+;dump = deferred_ctx_accurate share_dupes ps-t0 mono dds
 $shader_type = 5
 if $costume_mods && $shadow_mode == 1
 	ResourceBakVB = ref vb0
@@ -1592,6 +1810,54 @@ if $costume_mods && $shadow_mode == 1
 endif
 if $shadow_mode == 2
 	handling = skip
+endif
+
+[ShaderOverrideWater-Old]
+; Moving Water
+; Bytecode hash: 4b4b431a
+hash = ea320288619c5ee6
+run = CommandListEnvironment
+[ShaderOverrideWater-20200610]
+; Bytecode hash: 19eb5ff4
+hash = 0f0a2c40c629c533
+run = CommandListEnvironment
+
+[ShaderOverrideVenusCard-Old]
+; Bytecode hash: ?
+hash = 022ead00ab05e856
+run = CommandListEnvironment
+[ShaderOverrideVenusCard-20200610]
+; Bytecode hash: 3be88682
+hash = 892f7246173bea98
+run = CommandListEnvironment
+
+; Palm Tree Leafs
+[ShaderOverridePalmTrees-Old]
+; Bytecode hash: edfcd195
+hash = b9e5304ff1a48451
+run = CommandListEnvironment
+[ShaderOverridePalmTrees-20200610]
+; Bytecode hash: 112feb5a
+hash = ae68b2fe0f16091a
+run = CommandListEnvironment
+
+[CommandListEnvironment]
+;analyse_options = deferred_ctx_accurate share_dupes dump_vb txt buf
+;dump = deferred_ctx_accurate share_dupes ps-t0 mono dds
+$shader_type = 7
+if $costume_mods
+	ResourceBakVB = ref vb0
+	ResourceBakIB = ref ib
+	; Eliminates light shining through where the holes used to be:
+	checktextureoverride = vb0
+	checktextureoverride = ib
+	checktextureoverride = ps-t0
+	checktextureoverride = ps-t1
+	; Game doesn't rebind original vb + ib every draw call, so to make sure we
+	; don't have missing s hadows from other sub-parts of this mesh we restore what
+	; the game was using:
+	vb0 = ref ResourceBakVB
+	ib = ref ResourceBakIB
 endif
 
 [KeyToggleMods]

--- a/DOAX-VenusVacation/d3dx.ini
+++ b/DOAX-VenusVacation/d3dx.ini
@@ -1593,6 +1593,11 @@ run = CommandListShadowMap
 ; Bytecode hash: 8f17fd19
 hash = aeddebfe92d2e902
 run = CommandListShadowMap
+[ShaderOverrideClothesShadow3]
+; Misaki SR (Mills Mess) Bikini Ties
+; Bytecode hash: 4ebe7451
+hash = 5c8cb360ba8afa6d
+run = CommandListShadowMap
 
 [CommandListClothes]
 $shader_type = 1

--- a/DOAX-VenusVacation/d3dx.ini
+++ b/DOAX-VenusVacation/d3dx.ini
@@ -1812,6 +1812,16 @@ if $shadow_mode == 2
 	handling = skip
 endif
 
+[ShaderOverrideTanPS]
+; NOTE: Only executed when the tan textures are updated, e.g.
+; by clicking on the sunscreen buttons.
+hash = c65ebfdf7e4e8f50
+allow_duplicate_hash=overrule
+$shader_type = 6
+if $costume_mods
+  checktextureoverride = ps-t0
+endif
+
 [ShaderOverrideWater-Old]
 ; Moving Water
 ; Bytecode hash: 4b4b431a


### PR DESCRIPTION
Updated hashes for updated shaders in DMM version from June 10, 2020
bytecodes calculated for all new shaders
Added shaders used by newer mods since last update from April 2019
Added new commandlist shader_type archtype to accomodate non-character rendering shaders for things like water, cards, trees, etc
Switched Hair mods to be enabled by default given the increased number of released hair mods
