### PR TITLE
Improvement to blender_3dmigoto.py write_ini function to export mods

### DIFF
--- a/blender_3dmigoto.py
+++ b/blender_3dmigoto.py
@@ -1346,9 +1346,9 @@ def import_3dmigoto_vb_ib(operator, context, paths, flip_texcoord_v=True, flip_w
     obj['3DMigoto:FlipWinding'] = flip_winding
     obj['3DMigoto:FlipNormal'] = flip_normal
     # Store hashes for .ini mod generation when exporting
-    obj['3DMigoto:VBHash'] = re.search(r'(?<=-vb[0-9]=).*?(?=-)', name)
-    obj['3DMigoto:VSHash'] = re.search(r'(?<=-vs=).*?(?=-)', name)
-    obj['3DMigoto:PSHash'] = re.search(r'(?<=-ps=).*?(?=$|\.)', name)
+    obj['3DMigoto:VBHash'] = re.search(r'(?<=-vb[0-9]=).*?(?=-)', name).group() if re.search(r'(?<=-vb[0-9]=).*?(?=-)', name) else None
+    obj['3DMigoto:VSHash'] = re.search(r'(?<=-vs=).*?(?=-)', name).group() if re.search(r'(?<=-vs=).*?(?=-)', name) else None
+    obj['3DMigoto:PSHash'] = re.search(r'(?<=-ps=).*?(?=$|\.)', name).group() if re.search(r'(?<=-ps=).*?(?=$|\.)', name) else None
     
     if ib is not None:
         if ib.topology in ('trianglelist', 'trianglestrip'):


### PR DESCRIPTION
QOL Improvement to export mods including a possible workaround to avoid multiple shaderoverrides.

Sample automatically generated file
![imagen](https://github.com/DarkStarSword/3d-fixes/assets/63649241/fc96d68d-a174-41c6-8d7f-39cbf9c49ae7)

As you can see, that .ini does not have a ShaderOverride. 
The script now demands the user to export the mod into a folder which must be created inside the "Mods" folder, next to the executable. Example: MyGame/Mods/MyMod/Mymod.ini
It also creates a folder called ShaderOverrides next to the executable.
![imagen](https://github.com/DarkStarSword/3d-fixes/assets/63649241/76c7aaff-54e3-46e1-9ddd-6f76fa060fdd)

This folder will contain multiple files, each filenamed by their very own hash and only containing their respective single override
![imagen](https://github.com/DarkStarSword/3d-fixes/assets/63649241/99b31c51-f01f-486f-85f1-5b4ca5772ece)

By using this new ShaderOverrides folder, users can avoid conflicts when uploading their mods to websites. A shader hash will never be called twice again.
This change will need to modify the d3dx.ini from 3DMigoto's github page to include the new folder
![imagen](https://github.com/DarkStarSword/3d-fixes/assets/63649241/236d6868-ee39-4c55-82fc-5f990d8c5962)

The user now also has a new option when exporting, to choose overriding the vertex shader instead
![imagen](https://github.com/DarkStarSword/3d-fixes/assets/63649241/63c5db5c-89c2-478e-8a68-a31c463d78e2)

