### PR TITLE
Remove old .vb before writing segmented .vb_ files

### DIFF
--- a/blender_3dmigoto.py
+++ b/blender_3dmigoto.py
@@ -651,6 +651,8 @@ class VertexBufferGroup(object):
                     vertex[semantic] = (0, 0, 0, 0)
 
     def write(self, output_prefix, strides, operator=None):
+        if os.path.exists(output_prefix):
+            os.remove(output_prefix) # Remove old .vb if it exists before writing segmented .vb_ files
         for vbuf_idx, stride in strides.items():
             with open(output_prefix + vbuf_idx, 'wb') as output:
                 for vertex in self.vertices:


### PR DESCRIPTION
When importing .fmt/.ib/.vb into Blender, and exporting as .fmt/.ib/.vb0, the old .vb file is orphaned.  This pull request is code to remove the orphaned file.  (Otherwise both the .vb and .vb0 files appear in the import dialogue in Blender in the future, which is confusing.)